### PR TITLE
Update genPatch default module

### DIFF
--- a/scripts/genPatch.py
+++ b/scripts/genPatch.py
@@ -78,7 +78,7 @@ def getSymAddrFromMap(target, regexStr, symStr):
         loadAddrAdjustment = int(patchConfig["nso_load_addr"][target], 16)
     else:
         mapFile = SLMapFile
-        loadAddrAdjustment = int(patchConfig["nso_load_addr"]["subsdk0"], 16)
+        loadAddrAdjustment = int(patchConfig["nso_load_addr"]["subsdk1"], 16)
 
     foundPos, firstFoundAddr = getFoundPosAddr(0)
     if foundPos == -1:


### PR DESCRIPTION
When making a patch, we'll need to be able to tell where a given symbol is relative to us.

Essentially, this change is just saying that, since our custom code will live in module `subsdk1`, we should use that module's load address when computing branch offsets (there's an example of that calculation in #1 for more context).

The main thing to note is that this should just be the module where your custom code lives. In the original Starlight, it's `subsdk0`, presumably because Splatoon 2 doesn't ship with a `subsdk0` module by default. Vanilla SMO does have a `subsdk0`, so our custom code will go in the next module up (`subsdk1`), hence this change.