### PR TITLE
Update exported symbols

### DIFF
--- a/exported.txt
+++ b/exported.txt
@@ -1,7 +1,5 @@
 {
     global:
-        _Z6renderPN3agl11DrawContextEPN4sead10TextWriterE;
-        __custom_init;
-        __custom_fini;
+        _Z21teleportMarioIfNeededv;
     local: *;
 };


### PR DESCRIPTION
We now have a patch that references `teleportMarioIfNeeded`, and a function of the same name defined in our C++ code.

But if we run `make`, patch generation will fail with:

```
error: cannot resolve teleportMarioIfNeeded
```

This is because our function isn't currently included in the final binary. We need to include the symbols we care about in the version script that's passed to the linker — i.e., `exported.txt` in the project root.

There's no Starlight-specific way to generate this file, and I do not know of the best way to generate it separately; so I have manually edited the file to include the relevant symbol.